### PR TITLE
keystore: handle mixed case aliases

### DIFF
--- a/salt/states/keystore.py
+++ b/salt/states/keystore.py
@@ -99,7 +99,7 @@ def managed(name, passphrase, entries, force_remove=False):
             if force_remove:
                 keep_list.append(entry["alias"])
 
-            existing_entry = __salt__["keystore.list"](name, passphrase, entry["alias"])
+            existing_entry = __salt__["keystore.list"](name, passphrase, entry["alias"].lower())
             if existing_entry:
                 existing_sha1 = existing_entry[0]["sha1"]
                 new_sha1 = __salt__["x509.read_certificate"](entry["certificate"])[


### PR DESCRIPTION
Aliases in mixed case will be added to the keystore as lowercase.
We do a case sensitive match when checking for alias presence. Make it case insensitive.

### Previous Behavior
Given a mixed case alias keystore.manage state complains about alias already being present when it tires to call the keystore.add module.

### New Behavior
keystore.manage will not try to re-add a mixed case alias.
